### PR TITLE
Adding energy flexibility metrics to accounting package.

### DIFF
--- a/docs/costs.rst
+++ b/docs/costs.rst
@@ -5,6 +5,7 @@
 *****
 costs
 *****
+
 This module consists of code that computes a user's electricity bill given an electricity consumption profile.
 
 .. automodule:: electric_emission_cost.costs

--- a/docs/emissions.rst
+++ b/docs/emissions.rst
@@ -5,6 +5,7 @@
 *********
 emissions
 *********
+
 This module consists of code that computes Scope 2 emissions given an electricity consumption profile.
 
 .. automodule:: electric_emission_cost.emissions

--- a/docs/hello.rst
+++ b/docs/hello.rst
@@ -33,9 +33,20 @@ These functions can be performed in three different modes:
 
 More information about how to correctly format data inputs can be found in :ref:`dataformat`.
 
-.. _virtualbattery:
+.. _batteryoptimization:
 
-Sample Model: Virtual Battery
-=============================
+Sample Model: Battery Optimization
+====================================
 
-Besides the core functionality and utility functions, a simple virtual battery model is included as an example.
+Besides the core functionality and utility functions, a simple electric battery model (Pyomo) is included as an example.
+The model uses a linear program to minimize the electricity cost of a facility + battery subject to the baseline power consumption of the facility, dynamic constraints associated with battery charging and discharging, and the rules of the electricity tariff. 
+This example is not intended to comprehensive model battery dynamics, but rather a illustrate how to use the ``electric-emission-cost`` package in within and outside of an optimization problem.
+
+The model file is located in the ``examples`` directory, and can be run with the following command after installing in editable mode:
+.. code-block:: bash
+
+    python examples/battery_optimization.py
+
+A full walkthrough to use this example is available in the Jupyter notebook within the `github repository <https://github.com/we3lab/electric-emission-cost/blob/main/examples/example_pyomo_jupyter.ipynb>` at ``examples/example_pyomo_jupyter.ipynb``.
+
+s

--- a/docs/hello.rst
+++ b/docs/hello.rst
@@ -48,5 +48,3 @@ The model file is located in the ``examples`` directory, and can be run with the
     python examples/battery_optimization.py
 
 A full walkthrough to use this example is available in the Jupyter notebook within the `github repository <https://github.com/we3lab/electric-emission-cost/blob/main/examples/example_pyomo_jupyter.ipynb>` at ``examples/example_pyomo_jupyter.ipynb``.
-
-s

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -2,9 +2,10 @@
 
 .. _metrics:
 
-*****
+*******
 metrics
-*****
+*******
+
 This module consists of code that computes virtual battery metrics associated with energy flexible operation. 
 
 .. automodule:: electric_emission_cost.metrics

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -1,0 +1,11 @@
+.. contents::
+
+.. _metrics:
+
+*****
+metrics
+*****
+This module consists of code that computes virtual battery metrics associated with energy flexible operation. 
+
+.. automodule:: electric_emission_cost.metrics
+   :members:

--- a/docs/units.rst
+++ b/docs/units.rst
@@ -5,6 +5,7 @@
 *****
 units
 *****
+
 This module consists of the Pint unit dictionary.
 
 .. automodule:: electric_emission_cost.units

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -5,6 +5,7 @@
 *****
 utils
 *****
+
 This module consists of helpful utility functions
 
 .. automodule:: electric_emission_cost.utils

--- a/electric_emission_cost/metrics.py
+++ b/electric_emission_cost/metrics.py
@@ -5,7 +5,8 @@ import numpy as np
 
 
 def roundtrip_efficiency(baseline_kW, flexible_kW):
-    """Calculate the round-trip efficiency of a flexibly operating power trajectory relative to a baseline.
+    """Calculate the round-trip efficiency of a flexibly operating power trajectory
+    relative to a baseline.
 
     Parameters
     ----------
@@ -13,27 +14,35 @@ def roundtrip_efficiency(baseline_kW, flexible_kW):
         power consumption data of the baseline system in units of kW
 
     flexible_kW : list or np.ndarray
-        power consumption data of the flexibly operating or cost-optimized system in units of kW.
+        power consumption data of the flexibly operating or cost-optimized system
+        in units of kW.
 
     Raises
     ------
     TypeError
-        When `baseline_kW` and `flexible_kW` are not an acceptable type (e.g., list vs. np.ndarray).
+        When `baseline_kW` and `flexible_kW` are not an acceptable type
+        (e.g., list vs. np.ndarray).
+
     ValueError
         When `baseline_kW` and `flexible_kW` are not of the same length
+
     Warnings
-        When `baseline_kW` and `flexible_kW` contain negative values, which may indicate an error in the data.
+        When `baseline_kW` and `flexible_kW` contain negative values,
+        which may indicate an error in the data.
+
     ValueError
         When `baseline_kW` and `flexible_kW` contain missing values.
+
     Warnings
-        When rte is calculated to be greater than 1. This may indicate an error in the assumptions behind the data.
+        When rte is calculated to be greater than 1.
+        This may indicate an error in the assumptions behind the data.
 
     Returns
     -------
     float
-        The round-trip efficiency [0,1] of the flexible power trajectory relative to the baseline.
+        The round-trip efficiency [0,1] of the flexible power trajectory
+        relative to the baseline.
     """
-
     # Check if inputs are lists or numpy arrays
     if not isinstance(baseline_kW, (list, np.ndarray)):
         raise TypeError("baseline_kW must be a list or numpy array.")
@@ -51,12 +60,14 @@ def roundtrip_efficiency(baseline_kW, flexible_kW):
     # Check for negative or missing values
     if np.any(baseline_kW < 0) or np.any(flexible_kW < 0):
         warnings.warn(
-            "Negative values detected in baseline_kW or flexible_kW. This may indicate an error in the data."
+            "Negative values detected in baseline_kW or flexible_kW. "
+            "This may indicate an error in the data."
         )
 
     if np.any(np.isnan(baseline_kW)) or np.any(np.isnan(flexible_kW)):
         raise ValueError(
-            "Missing values detected in baseline_kW or flexible_kW. This may indicate an error in the data."
+            "Missing values detected in baseline_kW or flexible_kW. "
+            "This may indicate an error in the data."
         )
 
     # Calculate the round-trip efficiency
@@ -68,7 +79,8 @@ def roundtrip_efficiency(baseline_kW, flexible_kW):
     rte_value = baseline_energy / flexible_energy
     if rte_value > 1:
         warnings.warn(
-            "RTE calculated to be greater than 1. This may indicate an error in the assumptions behind the data."
+            "RTE calculated to be greater than 1. "
+            "This may indicate an error in the assumptions behind the data."
         )
 
     return rte_value
@@ -85,24 +97,32 @@ def power_capacity(
     ----------
     baseline_kW : array-like
         The baseline power consumption of the facility in kW.
+
     flexible_kW : array-like
         The flexible power consumption of the facility in kW.
+
     timestep : float
         The time step of the data in hours. Default is 0.25 hours (15 minutes).
+
     pc_type : str
-        The type of power capacity to calculate. Options are 'average', 'charging', 'discharging', 'maximum'
+        The type of power capacity to calculate.
+        Options are 'average', 'charging', 'discharging', 'maximum'
+
     relative : bool
-        If True, return the fractional power capacity. If False, return the absolute power capacity.
+        If True, return the fractional power capacity.
+        If False, return the absolute power capacity.
 
     Raises
     ------
     ValueError
-        If `pc_type` is not one of the expected values ('average', 'charging', 'discharging', 'maximum').
+        If `pc_type` is not one of the expected values
+        ('average', 'charging', 'discharging', 'maximum').
 
     Returns
     -------
     float
-        The power capacity of the virtual battery system in either relative or absolute terms.
+        The power capacity of the virtual battery system in either relative
+        or absolute terms.
     """
     # calculate the effective battery power (diff)
     diff_kW = flexible_kW - baseline_kW
@@ -121,7 +141,8 @@ def power_capacity(
         power_capacity = np.max(np.abs(diff_kW))
     else:
         raise ValueError(
-            "Invalid power capacity type. Must be 'average', 'charging', 'discharging', or 'maximum'."
+            "Invalid power capacity type. Must be 'average', "
+            "'charging', 'discharging', or 'maximum'."
         )
 
     if relative:
@@ -135,30 +156,39 @@ def energy_capacity(
     baseline_kW, flexible_kW, timestep=0.25, ec_type="discharging", relative=True
 ):
     """
-    Calculate the round trip efficiency of a virtual battery system. This approach implicitly assumes the system has completed a round-trip.
+    Calculate the round trip efficiency of a virtual battery system.
+    This approach implicitly assumes the system has completed a round-trip.
 
     Parameters
     ----------
     baseline_kW : array-like
         The baseline power consumption of the facility in kW.
+
     flexible_kW : array-like
         The flexible power consumption of the facility in kW.
+
     timestep : float
         The time step of the data in hours. Default is 0.25 hours (15 minutes).
+
     ec_type : str
-        The type of power capacity to calculate. Options are 'average', 'charging', 'discharging'
+        The type of power capacity to calculate.
+        Options are 'average', 'charging', 'discharging'
+
     relative : bool
-        If True, return the fractional power capacity. If False, return the absolute power capacity.
+        If True, return the fractional power capacity.
+        If False, return the absolute power capacity.
 
     Raises
     ------
     ValueError
-        If `ec_type` is not one of the expected values ('average', 'charging', 'discharging').
+        If `ec_type` is not one of the expected values
+        ('average', 'charging', 'discharging').
 
     Returns
     -------
     float
-        The power capacity of the virtual battery system in either relative or absolute terms.
+        The power capacity of the virtual battery system in either relative
+        or absolute terms.
     """
     # calculate the effective battery power (diff)
     diff_kW = flexible_kW - baseline_kW
@@ -175,7 +205,8 @@ def energy_capacity(
         energy_capacity = np.sum(discharging) * timestep
     else:
         raise ValueError(
-            "Invalid energy capacity type. Must be 'average', 'charging', or 'discharging'."
+            "Invalid energy capacity type. "
+            "Must be 'average', 'charging', or 'discharging'."
         )
 
     if relative:
@@ -206,37 +237,49 @@ def net_present_value(
     ----------
     capital_cost : float
         The capital cost of the virtual battery system in $.
+
     electricity_savings : float
         The electricity savings from the flexible operation in $.
+
     maintenance_diff : float
         The difference in maintenance costs between the baseline
         and flexible operation in $.
+
     ancillary_service_benefit : float
         The benefit from providing ancillary services in $.
+
     service_curtailment : float
         The amount of service curtailment. If the virtual battery system produces
         a product, this may be in units of volume or mass (e.g., m^3 or kg).
+
     service_price : float
         The marginal price of curtailed service $/amount.
         Amount here may refer to units of volume or mass (e.g., $/m^3 or $/kg).
+
     timestep : float
         The time step of the data in hours. Default is 0.25 hours (15 minutes).
+
     simulation_years : int
         The number of years in which the electricity savings or
         ancillary service benefits are calculated for. Default is 1 year.
+
     upgrade_lifetime : int
         The number of years of operation left for the upgrade. Default is 30 years.
+
     interest_rate : float
         The interest rate used to discount future cash flows. Default is 0.03.
 
     Raises
     ------
     Warning
-        if the capital cost is less than 0
+        If the capital cost is less than 0
+
     ValueError
-        if the upgrade lifetime is less than or equal to 0
+        If the upgrade lifetime is less than or equal to 0
+
     ValueError
-    if the interest rate is less than 0.
+        If the interest rate is less than 0.
+
     ValueError
         if the timestep is less than or equal to 0.
 

--- a/electric_emission_cost/metrics.py
+++ b/electric_emission_cost/metrics.py
@@ -2,7 +2,6 @@
 
 import warnings
 import numpy as np
-from . import utils as ut
 
 
 def roundtrip_efficiency(baseline_kW, flexible_kW):
@@ -210,20 +209,20 @@ def net_present_value(
     electricity_savings : float
         The electricity savings from the flexible operation in $.
     maintenance_diff : float
-        The difference in maintenance costs between the baseline 
+        The difference in maintenance costs between the baseline
         and flexible operation in $.
     ancillary_service_benefit : float
         The benefit from providing ancillary services in $.
     service_curtailment : float
-        The amount of service curtailment. If the virtual battery system produces 
+        The amount of service curtailment. If the virtual battery system produces
         a product, this may be in units of volume or mass (e.g., m^3 or kg).
     service_price : float
-        The marginal price of curtailed service $/amount. 
+        The marginal price of curtailed service $/amount.
         Amount here may refer to units of volume or mass (e.g., $/m^3 or $/kg).
     timestep : float
         The time step of the data in hours. Default is 0.25 hours (15 minutes).
     simulation_years : int
-        The number of years in which the electricity savings or 
+        The number of years in which the electricity savings or
         ancillary service benefits are calculated for. Default is 1 year.
     upgrade_lifetime : int
         The number of years of operation left for the upgrade. Default is 30 years.
@@ -265,9 +264,6 @@ def net_present_value(
     benefit = electricity_savings + ancillary_service_benefit
     cost = maintenance_diff + service_curtailment * service_price
     cash_flow = benefit - cost
-
-    # calculate the time extrapolation factor
-    time_scaling = simulation_years / upgrade_lifetime
 
     # calculate the net discount factor
     discount = sum([1 / ((1 + interest_rate) ** n) for n in range(1, upgrade_lifetime)])

--- a/electric_emission_cost/metrics.py
+++ b/electric_emission_cost/metrics.py
@@ -89,8 +89,7 @@ def roundtrip_efficiency(baseline_kW, flexible_kW):
 def power_capacity(
     baseline_kW, flexible_kW, timestep=0.25, pc_type="average", relative=True
 ):
-    """
-    Calculate the round trip efficiency of a virtual battery system.
+    """Calculate the power capacity of a virtual battery system.
     This approach implicitly assumes the system has completed a round-trip.
 
     Parameters
@@ -155,8 +154,7 @@ def power_capacity(
 def energy_capacity(
     baseline_kW, flexible_kW, timestep=0.25, ec_type="discharging", relative=True
 ):
-    """
-    Calculate the round trip efficiency of a virtual battery system.
+    """Calculate the energy capacity of a virtual battery system.
     This approach implicitly assumes the system has completed a round-trip.
 
     Parameters
@@ -171,12 +169,12 @@ def energy_capacity(
         The time step of the data in hours. Default is 0.25 hours (15 minutes).
 
     ec_type : str
-        The type of power capacity to calculate.
+        The type of energy capacity to calculate.
         Options are 'average', 'charging', 'discharging'
 
     relative : bool
-        If True, return the fractional power capacity.
-        If False, return the absolute power capacity.
+        If True, return the fractional energy capacity.
+        If False, return the absolute energy capacity.
 
     Raises
     ------
@@ -187,7 +185,7 @@ def energy_capacity(
     Returns
     -------
     float
-        The power capacity of the virtual battery system in either relative
+        The energy capacity of the virtual battery system in either relative
         or absolute terms.
     """
     # calculate the effective battery power (diff)

--- a/electric_emission_cost/metrics.py
+++ b/electric_emission_cost/metrics.py
@@ -210,17 +210,21 @@ def net_present_value(
     electricity_savings : float
         The electricity savings from the flexible operation in $.
     maintenance_diff : float
-        The difference in maintenance costs between the baseline and flexible operation in $.
+        The difference in maintenance costs between the baseline 
+        and flexible operation in $.
     ancillary_service_benefit : float
         The benefit from providing ancillary services in $.
     service_curtailment : float
-        The amount of service curtailment. If the virtual battery system produces a product, this may be in units of volume or mass (e.g., m^3 or kg).
+        The amount of service curtailment. If the virtual battery system produces 
+        a product, this may be in units of volume or mass (e.g., m^3 or kg).
     service_price : float
-        The marginal price of curtailed service $/amount. Amount here may refer to units of volume or mass (e.g., $/m^3 or $/kg).
+        The marginal price of curtailed service $/amount. 
+        Amount here may refer to units of volume or mass (e.g., $/m^3 or $/kg).
     timestep : float
         The time step of the data in hours. Default is 0.25 hours (15 minutes).
     simulation_years : int
-        The number of years in which the electricity savings or ancillary service benefits are calculated for. Default is 1 year.
+        The number of years in which the electricity savings or 
+        ancillary service benefits are calculated for. Default is 1 year.
     upgrade_lifetime : int
         The number of years of operation left for the upgrade. Default is 30 years.
     interest_rate : float

--- a/electric_emission_cost/metrics.py
+++ b/electric_emission_cost/metrics.py
@@ -1,0 +1,251 @@
+"""Functions to estimate flexibility metrics from power consumption trajectories."""
+import warnings
+import numpy as np
+from . import utils as ut
+
+def rte(baseline_kW, flexible_kW):
+    """Calculate the Round-trip efficiency of a flexibly operating power trajectory relative to a baseline.
+    
+    Parameters
+    ----------
+    baseline_kW : list or np.ndarray
+        power consumption data of the baseline system in units of kW
+
+    flexible_kW : list or np.ndarray
+        power consumption data of the flexibly operating or cost-optimized system in units of kW.
+
+    Raises
+    ------
+    TypeError
+        When `baseline_kW` and `flexible_kW` are not an acceptable type (e.g., list vs. np.ndarray).
+    ValueError
+        When `baseline_kW` and `flexible_kW` are not of the same length
+    Warnings
+        When `baseline_kW` and `flexible_kW` contain negative values, which may indicate an error in the data.
+    ValueError
+        When `baseline_kW` and `flexible_kW` contain missing values.
+    Warnings
+        When rte is calculated to be greater than 1. This may indicate an error in the assumptions behind the data.
+
+    Returns
+    -------
+    float
+        The round-trip efficiency [0,1] of the flexible power trajectory relative to the baseline.
+    """
+
+    # Check if inputs are lists or numpy arrays
+    if not isinstance(baseline_kW, (list, np.ndarray)):
+        raise TypeError("baseline_kW must be a list or numpy array.")
+    if not isinstance(flexible_kW, (list, np.ndarray)):
+        raise TypeError("flexible_kW must be a list or numpy array.")
+
+    # Check if inputs are of the same length
+    if len(baseline_kW) != len(flexible_kW):
+        raise ValueError("baseline_kW and flexible_kW must have the same length.")
+
+    # Convert inputs to numpy arrays for easier calculations
+    baseline_kW = np.array(baseline_kW)
+    flexible_kW = np.asarray(flexible_kW)
+
+    # Check for negative or missing values
+    if np.any(baseline_kW < 0) or np.any(flexible_kW < 0):
+        warnings.warn("Negative values detected in baseline_kW or flexible_kW. This may indicate an error in the data.")
+    
+    if np.any(np.isnan(baseline_kW)) or np.any(np.isnan(flexible_kW)):
+        raise ValueError("Missing values detected in baseline_kW or flexible_kW. This may indicate an error in the data.")
+
+    # Calculate the round-trip efficiency
+    baseline_energy = np.sum(baseline_kW)
+    flexible_energy = np.sum(flexible_kW)
+    if flexible_energy == 0:
+        raise ValueError("The sum of flexible_kW is zero, cannot compute rte.")
+    
+    rte_value = baseline_energy / flexible_energy
+    if rte_value > 1:
+        warnings.warn("RTE calculated to be greater than 1. This may indicate an error in the assumptions behind the data.")
+
+    return rte_value
+
+
+def calc_power_capacity(baseline_kW, flexible_kW, timestep=0.25, pc_type='average', relative=True):
+    """
+    Calculate the round trip efficiency of a virtual battery system.
+    This approach implicitly assumes the system has completed a round-trip.
+    
+    Parameters
+    ----------
+    baseline_kW : array-like
+        The baseline power consumption of the facility in kW.
+    flexible_kW : array-like
+        The flexible power consumption of the facility in kW.
+    timestep : float
+        The time step of the data in hours. Default is 0.25 hours (15 minutes).
+    pc_type : str
+        The type of power capacity to calculate. Options are 'average', 'charging', 'discharging', 'maximum'
+    relative : bool
+        If True, return the fractional power capacity. If False, return the absolute power capacity.
+    
+    Raises
+    ------
+    ValueError
+        If `pc_type` is not one of the expected values ('average', 'charging', 'discharging', 'maximum').
+    
+    Returns
+    -------
+    float
+        The power capacity of the virtual battery system in either relative or absolute terms.
+    """
+    # calculate the effective battery power (diff)
+    diff_kW = flexible_kW - baseline_kW
+    # charging is positive, discharging is negative
+    charging = np.where(diff_kW > 0, diff_kW, 0)
+    discharging = np.where(diff_kW < 0, -diff_kW, 0)
+
+    # calculate the power capacity
+    if pc_type == 'average':
+        power_capacity = (np.sum(charging) + np.sum(discharging)) / (len(diff_kW))
+    elif pc_type == 'charging':
+        power_capacity = np.sum(charging) / (len(charging))
+    elif pc_type == 'discharging':
+        power_capacity = np.sum(discharging) / (len(discharging))
+    elif pc_type == 'maximum':
+        power_capacity = np.max(np.abs(diff_kW))
+    else:
+        raise ValueError("Invalid power capacity type. Must be 'average', 'charging', 'discharging', or 'maximum'.")
+    
+    if relative:
+        # normalize by the max baseline power
+        return power_capacity / np.max(baseline_kW)
+    else:
+        return power_capacity
+
+def calc_energy_capacity(baseline_kW, flexible_kW, timestep=0.25, ec_type='discharging', relative=True):
+    """
+    Calculate the round trip efficiency of a virtual battery system. This approach implicitly assumes the system has completed a round-trip.
+    
+    Parameters
+    ----------
+    baseline_kW : array-like
+        The baseline power consumption of the facility in kW.
+    flexible_kW : array-like
+        The flexible power consumption of the facility in kW.
+    timestep : float
+        The time step of the data in hours. Default is 0.25 hours (15 minutes).
+    ec_type : str
+        The type of power capacity to calculate. Options are 'average', 'charging', 'discharging'
+    relative : bool
+        If True, return the fractional power capacity. If False, return the absolute power capacity.
+    
+    Raises
+    ------
+    ValueError
+        If `ec_type` is not one of the expected values ('average', 'charging', 'discharging').
+    
+    Returns
+    -------
+    float
+        The power capacity of the virtual battery system in either relative or absolute terms.
+    """
+    # calculate the effective battery power (diff)
+    diff_kW = flexible_kW - baseline_kW   
+    # charging is positive, discharging is negative
+    charging = np.where(diff_kW > 0, diff_kW, 0)
+    discharging = np.where(diff_kW < 0, -diff_kW, 0)
+
+    # calculate the energy capacity
+    if ec_type == 'average':
+        energy_capacity = (np.sum(charging) + np.sum(discharging)) * timestep
+    elif ec_type == 'charging':
+        energy_capacity = np.sum(charging) * timestep
+    elif ec_type == 'discharging':
+        energy_capacity = np.sum(discharging) * timestep
+    else:
+        raise ValueError("Invalid energy capacity type. Must be 'average', 'charging', or 'discharging'.")
+
+    if relative:
+        # normalize by the total baseline power
+        return energy_capacity / (np.sum(baseline_kW) * timestep + 1e-12)  # add small value to avoid division by zero
+    else:
+        return energy_capacity 
+
+def calc_npv(capital_cost=0, 
+                electricity_savings=0, 
+                maintenance_diff=0, 
+                ancillary_service_benefit=0, 
+                service_curtailment=0, 
+                service_price=1.0, 
+                timestep=0.25, 
+                simulation_years=1,
+                upgrade_lifetime=30,
+                interest_rate=0.03):
+    """
+    Calculate the net present value of flexibility of a virtual battery system.
+
+    Parameters
+    ----------
+    capital_cost : float
+        The capital cost of the virtual battery system in $.
+    electricity_savings : float  
+        The electricity savings from the flexible operation in $.
+    maintenance_diff : float
+        The difference in maintenance costs between the baseline and flexible operation in $.
+    ancillary_service_benefit : float
+        The benefit from providing ancillary services in $.
+    service_curtailment : float
+        The amount of service curtailment. If the virtual battery system produces a product, this may be in units of volume or mass (e.g., m^3 or kg).
+    service_price : float
+        The marginal price of curtailed service $/amount. Amount here may refer to units of volume or mass (e.g., $/m^3 or $/kg).
+    timestep : float
+        The time step of the data in hours. Default is 0.25 hours (15 minutes).
+    simulation_years : int
+        The number of years in which the electricity savings or ancillary service benefits are calculated for. Default is 1 year.
+    upgrade_lifetime : int
+        The number of years of operation left for the upgrade. Default is 30 years.
+    interest_rate : float
+        The interest rate used to discount future cash flows. Default is 0.03.
+
+    Raises
+    ------
+    Warning
+        if the capital cost is less than 0
+    ValueError
+        if the upgrade lifetime is less than or equal to 0 
+    ValueError    
+    if the interest rate is less than 0.
+    ValueError
+        if the timestep is less than or equal to 0.
+
+    Returns
+    -------
+    float
+        The net present value benefit of the virtual battery system in $.
+    """
+    # check if capital cost is negative
+    if capital_cost < 0:
+        warnings.warn("Capital cost is negative. This may indicate an error in the data.")
+    # check if upgrade lifetime is valid
+    if upgrade_lifetime <= 0:
+        raise ValueError("Upgrade lifetime must be greater than 0 years.")
+    # check if interest rate is valid
+    if interest_rate < 0:
+        raise ValueError("Interest rate must be greater than or equal to 0.")
+    # check if timestep is valid
+    if timestep <= 0:
+        raise ValueError("Timestep must be greater than 0 hours.")
+
+
+    # calculate the total cash flow
+    benefit = electricity_savings + ancillary_service_benefit
+    cost = maintenance_diff + service_curtailment * service_price
+    cash_flow = benefit - cost
+
+    # calculate the time extrapolation factor
+    time_scaling = simulation_years / upgrade_lifetime
+
+    # calculate the net discount factor
+    discount = sum([1/((1+interest_rate)**n) for n in range(1, upgrade_lifetime)])
+
+    # calculate the net present value
+    npv = discount * (cash_flow / simulation_years) - capital_cost
+
+    return npv

--- a/electric_emission_cost/tests/test_metrics.py
+++ b/electric_emission_cost/tests/test_metrics.py
@@ -72,6 +72,9 @@ def test_metrics(
     flexible_kW = np.random.normal(loc=1200, scale=300, size=len(baseline_kW))
     if metric == "rte":
         rte = metrics.roundtrip_efficiency(baseline_kW, flexible_kW)
+        # assert output is a float
+        assert isinstance(rte, float), "Round trip efficiency should be a float"
+
     elif metric == "pc":
         pc = metrics.power_capacity(
             baseline_kW,
@@ -80,6 +83,8 @@ def test_metrics(
             pc_type=power_capacity_type,
             relative=True,
         )
+        assert isinstance(pc, float), "Round trip efficiency should be a float"
+
     elif metric == "ec":
         ec = metrics.energy_capacity(
             baseline_kW,
@@ -88,6 +93,7 @@ def test_metrics(
             ec_type=energy_capacity_type,
             relative=True,
         )
+        assert isinstance(ec, float), "Round trip efficiency should be a float"
 
     return
 

--- a/electric_emission_cost/tests/test_metrics.py
+++ b/electric_emission_cost/tests/test_metrics.py
@@ -1,0 +1,100 @@
+import os
+import pytest
+import numpy as np
+import pandas as pd
+
+from electric_emission_cost import metrics
+
+os.chdir(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+skip_all_tests = False
+
+input_dir = "tests/data/input/"
+output_dir = "tests/data/output/"
+
+np.random.seed(0)
+
+
+@pytest.mark.skipif(skip_all_tests, reason="Exclude all tests")
+@pytest.mark.parametrize(
+    "metric, power_capacity_type, energy_capacity_type",
+    [
+        # test RTE
+        (
+            "rte",
+            None,
+            None,
+        ),
+        # test Power Capacity with options
+        (
+            "pc",
+            "average",
+            None,
+        ),
+        (
+            "pc",
+            "charging",
+            None,
+        ),
+        (
+            "pc",
+            "discharging",
+            None,
+        ),
+        (
+            "pc",
+            "maximum",
+            None,
+        ),
+        (
+            "ec",
+            None,
+            "average",
+        ),
+        (
+            "ec",
+            None,
+            "charging",
+        ),
+        (
+            "ec",
+            None,
+            "discharging",
+        ),
+    ],
+)
+def test_metrics(
+    metric, power_capacity_type, energy_capacity_type, baseline_datafile="flat_load.csv"
+):
+    flat_baseline_df = pd.read_csv(input_dir + baseline_datafile)
+    baseline_kW = flat_baseline_df["VirtualDemand_Electricity_InFlow"].values
+
+    # create a random load profile with the same length
+    flexible_kW = np.random.normal(loc=1200, scale=300, size=len(baseline_kW))
+    if metric == "rte":
+        rte = metrics.roundtrip_efficiency(baseline_kW, flexible_kW)
+    elif metric == "pc":
+        pc = metrics.power_capacity(
+            baseline_kW,
+            flexible_kW,
+            timestep=0.25,
+            pc_type=power_capacity_type,
+            relative=True,
+        )
+    elif metric == "ec":
+        ec = metrics.energy_capacity(
+            baseline_kW,
+            flexible_kW,
+            timestep=0.25,
+            ec_type=energy_capacity_type,
+            relative=True,
+        )
+
+    return
+
+
+@pytest.mark.skipif(skip_all_tests, reason="Exclude all tests")
+def test_npv():
+    npv = metrics.net_present_value(
+        capital_cost=0, electricity_savings=0, simulation_years=1, upgrade_lifetime=30
+    )  # default value is 0
+    assert npv == 0, "Net present value should be 0 by default"


### PR DESCRIPTION
Adding `metrics.py` in main + tests and docs. 

`metrics.py` contains calculations for the round-trip-efficiency, power capacity, energy capacity, and NPV for a flexibly operating asset. 