### PR TITLE
Hotfix/varstr

### DIFF
--- a/docs/hello.rst
+++ b/docs/hello.rst
@@ -33,9 +33,20 @@ These functions can be performed in three different modes:
 
 More information about how to correctly format data inputs can be found in :ref:`dataformat`.
 
-.. _virtualbattery:
+.. _batteryoptimization:
 
-Sample Model: Virtual Battery
-=============================
+Sample Model: Battery Optimization
+====================================
 
-Besides the core functionality and utility functions, a simple virtual battery model is included as an example.
+Besides the core functionality and utility functions, a simple electric battery model (Pyomo) is included as an example.
+The model uses a linear program to minimize the electricity cost of a facility + battery subject to the baseline power consumption of the facility, dynamic constraints associated with battery charging and discharging, and the rules of the electricity tariff. 
+This example is not intended to comprehensive model battery dynamics, but rather a illustrate how to use the ``electric-emission-cost`` package in within and outside of an optimization problem.
+
+The model file is located in the ``examples`` directory, and can be run with the following command after installing in editable mode:
+.. code-block:: bash
+
+    python examples/battery_optimization.py
+
+A full walkthrough to use this example is available in the Jupyter notebook within the `github repository <https://github.com/we3lab/electric-emission-cost/blob/main/examples/example_pyomo_jupyter.ipynb>` at ``examples/example_pyomo_jupyter.ipynb``.
+
+s

--- a/docs/hello.rst
+++ b/docs/hello.rst
@@ -48,5 +48,3 @@ The model file is located in the ``examples`` directory, and can be run with the
     python examples/battery_optimization.py
 
 A full walkthrough to use this example is available in the Jupyter notebook within the `github repository <https://github.com/we3lab/electric-emission-cost/blob/main/examples/example_pyomo_jupyter.ipynb>` at ``examples/example_pyomo_jupyter.ipynb``.
-
-s

--- a/electric_emission_cost/utils.py
+++ b/electric_emission_cost/utils.py
@@ -164,27 +164,31 @@ def max(expression, model=None, varstr=None):
     ([numpy.Array, cvxpy.Expression, pyomo.environ.Var], pyomo.environ.Model)
         Expression representing max of `expression`
     """
+    # replace any - with _ in varstr
+    varstr = re.sub("-", "_", varstr)
     if isinstance(
         expression, (LinearExpression, SumExpression, MonomialTermExpression, ScalarVar)
     ):
-        setattr(model, varstr, pyo.Var())
-        var = getattr(model, varstr)
+        model.add_component(name=varstr, val=pyo.Var())
+        var = model.find_component(varstr)
 
         def const_rule(model):
             return var >= expression
 
         constraint = pyo.Constraint(rule=const_rule)
-        setattr(model, varstr + "_constraint", constraint)
+        model.add_component(name=varstr + "_constraint", val=constraint)
         return (var, model)
+    
     elif isinstance(expression, (IndexedExpression, pyo.Param, pyo.Var)):
-        setattr(model, varstr, pyo.Var())
-        var = getattr(model, varstr)
+        model.add_component(name=varstr, val=pyo.Var())
+        var = model.find_component(varstr)
 
         def const_rule(model, t):
             return var >= expression[t]
 
         constraint = pyo.Constraint(model.t, rule=const_rule)
-        setattr(model, varstr + "_constraint", constraint)
+        model.add_component(name=varstr + "_constraint", val=constraint)
+
         return (var, model)
     elif isinstance(
         expression, (int, float, np.int32, np.int64, np.float32, np.float64, np.ndarray)
@@ -236,9 +240,11 @@ def sum(expression, axis=0, model=None, varstr=None):
     [numpy.Array, cvxpy.Expression, pyomo.environ.Expression]
         Expression representing sum of `expression` along `axis`
     """
+    # replace any - with _ in varstr
+    varstr = re.sub("-", "_", varstr)
     if isinstance(expression, (SumExpression, IndexedExpression, pyo.Param, pyo.Var)):
-        setattr(model, varstr, pyo.Var())
-        var = getattr(model, varstr)
+        model.add_component(name=varstr, val=pyo.Var())
+        var = model.find_component(varstr)
 
         def const_rule(model):
             total = 0
@@ -247,7 +253,7 @@ def sum(expression, axis=0, model=None, varstr=None):
             return var == total
 
         constraint = pyo.Constraint(rule=const_rule)
-        setattr(model, varstr + "_constraint", constraint)
+        model.add_component(name=varstr + "_constraint", val=constraint)
         return (var, model)
     elif isinstance(
         expression, (int, float, np.int32, np.int64, np.float32, np.float64, np.ndarray)
@@ -300,27 +306,29 @@ def max_pos(expression, model=None, varstr=None):
     )
         Expression representing maximum positive scalar value of `expression`
     """
+    # replace any - with _ in varstr
+    varstr = re.sub("-", "_", varstr)
     if isinstance(
         expression, (LinearExpression, SumExpression, MonomialTermExpression, ScalarVar)
     ):
-        setattr(model, varstr, pyo.Var(initialize=0, bounds=(0, None)))
-        var = getattr(model, varstr)
+        model.add_component(name=varstr, val=pyo.Var(initialize=0, bounds=(0, None)))
+        var = model.find_component(varstr)
 
         def const_rule(model):
             return var >= expression
 
         constraint = pyo.Constraint(rule=const_rule)
-        setattr(model, varstr + "_constraint", constraint)
+        model.add_component(name=varstr + "_constraint", val=constraint)
         return (var, model)
     elif isinstance(expression, (IndexedExpression, pyo.Param, pyo.Var)):
-        setattr(model, varstr, pyo.Var(bounds=(0, None)))
-        var = getattr(model, varstr)
+        model.add_component(name=varstr, val=pyo.Var(initialize=0, bounds=(0, None)))
+        var=model.find_component(varstr)
 
         def const_rule(model, t):
             return var >= expression[t]
 
         constraint = pyo.Constraint(model.t, rule=const_rule)
-        setattr(model, varstr + "_constraint", constraint)
+        model.add_component(name=varstr + "_constraint", val=constraint)
         return (var, model)
     elif isinstance(
         expression, (int, float, np.int32, np.int64, np.float32, np.float64, np.ndarray)
@@ -384,6 +392,8 @@ def multiply(expression1, expression2, model=None, varstr=None):
     ]
         result from elementwise multiplication of `expression1` and `expression2`
     """
+    # replace any - with _ in varstr
+    varstr = re.sub("-", "_", varstr)
     if isinstance(expression1, cp.Expression) or isinstance(expression2, cp.Expression):
         return (cp.multiply(expression1, expression2), None)
     elif isinstance(
@@ -393,14 +403,14 @@ def multiply(expression1, expression2, model=None, varstr=None):
     ):
         if len(expression1) > 1:
             # TODO: replace model.t with better way to get dimensions
-            setattr(model, varstr, pyo.Var(model.t))
-            var = getattr(model, varstr)
+            model.add_component(name=varstr, val=pyo.Var(model.t))
+            var = model.find_component(varstr)
 
             def const_rule(model, t):
                 return var[t] == expression1[t] * expression2[t]
 
             constraint = pyo.Constraint(model.t, rule=const_rule)
-            setattr(model, varstr + "_constraint", constraint)
+            model.add_component(name=varstr + "_constraint", val=constraint)
             return (var, model)
         else:
             return (expression1 * expression2, model)

--- a/electric_emission_cost/utils.py
+++ b/electric_emission_cost/utils.py
@@ -178,7 +178,7 @@ def max(expression, model=None, varstr=None):
         constraint = pyo.Constraint(rule=const_rule)
         model.add_component(name=varstr + "_constraint", val=constraint)
         return (var, model)
-    
+
     elif isinstance(expression, (IndexedExpression, pyo.Param, pyo.Var)):
         model.add_component(name=varstr, val=pyo.Var())
         var = model.find_component(varstr)
@@ -322,7 +322,7 @@ def max_pos(expression, model=None, varstr=None):
         return (var, model)
     elif isinstance(expression, (IndexedExpression, pyo.Param, pyo.Var)):
         model.add_component(name=varstr, val=pyo.Var(initialize=0, bounds=(0, None)))
-        var=model.find_component(varstr)
+        var = model.find_component(varstr)
 
         def const_rule(model, t):
             return var >= expression[t]


### PR DESCRIPTION
Removing `-` marks from varstrings when creating pyomo components in utils.