### PR TITLE
Add variable naming and sanitization code

### DIFF
--- a/electric_emission_cost/costs.py
+++ b/electric_emission_cost/costs.py
@@ -812,7 +812,8 @@ def calculate_cost(
             f_no_dates=lambda utility,
             charge_type, name,
             start_date, end_date,
-            charge_limit: f"{utility}_{charge_type}_{name}_{charge_limit}"
+            charge_limit:
+            f"{utility}_{charge_type}_{name}_{charge_limit}"
 
 
     Raises

--- a/electric_emission_cost/costs.py
+++ b/electric_emission_cost/costs.py
@@ -798,7 +798,8 @@ def calculate_cost(
         Only used in the case of Pyomo, so `None` by default.
 
     varstr_alias_func: function
-        Function to generate variable name for pyomo, should take in a 6 inputs and generate a string output.
+        Function to generate variable name for pyomo,
+        should take in a 6 inputs and generate a string output.
         The function will receive following six inputs:
         - utility: str
         - charge_type: str

--- a/electric_emission_cost/costs.py
+++ b/electric_emission_cost/costs.py
@@ -808,8 +808,11 @@ def calculate_cost(
         - charge_limit: str
 
         Examples of functions:
-            f_no_dates=lambda utility, charge_type, name, start_date, end_date, charge_limit: f"{utility}_{charge_type}_{name}_{charge_limit}"
-            f_default=lambda utility, charge_type, name, start_date, end_date, charge_limit: f"{utility}_{charge_type}_{name}_{start_date}_{end_date}_{charge_limit}"
+            f_no_dates=lambda utility,
+            charge_type, name,
+            start_date, end_date,
+            charge_limit: f"{utility}_{charge_type}_{name}_{charge_limit}"
+
 
     Raises
     ------
@@ -827,9 +830,14 @@ def calculate_cost(
     n_per_hour = int(60 / ut.get_freq_binsize_minutes(resolution))
     n_per_day = n_per_hour * 24
     if varstr_alias_func is None:
-        varstr_alias_func = lambda utility, charge_type, name, start_date, end_date, charge_limit: f"{utility}_{charge_type}_{name}_{start_date}_{end_date}_{charge_limit}".replace(
-            "-", "_"
-        )
+
+        def varstr_alias_func(
+            utility, charge_type, name, start_date, end_date, charge_limit
+        ):
+            return f"{utility}_{charge_type}_{name}_{start_date}_{end_date}_{charge_limit}".replace(
+                "-", "_"
+            )
+
     for key, charge_array in charge_dict.items():
         utility, charge_type, name, eff_start, eff_end, limit_str = key.split("_")
         var_str = ut.sanitize_varstr(

--- a/electric_emission_cost/costs.py
+++ b/electric_emission_cost/costs.py
@@ -834,8 +834,8 @@ def calculate_cost(
         def varstr_alias_func(
             utility, charge_type, name, start_date, end_date, charge_limit
         ):
-            return f"{utility}_{charge_type}_{name}_{start_date}_{end_date}_{charge_limit}".replace(
-                "-", "_"
+            return (
+                f"{utility}_{charge_type}_{name}_{start_date}_{end_date}_{charge_limit}"
             )
 
     for key, charge_array in charge_dict.items():

--- a/electric_emission_cost/costs.py
+++ b/electric_emission_cost/costs.py
@@ -736,6 +736,7 @@ def calculate_cost(
     desired_charge_type=None,
     demand_scale_factor=1,
     model=None,
+    varstr_alias_func=None,
 ):
     """Calculates the cost of given charges (demand or energy) for the given
     billing rate structure, utility, and consumption information as a
@@ -796,6 +797,20 @@ def calculate_cost(
         The model object associated with the problem.
         Only used in the case of Pyomo, so `None` by default.
 
+    varstr_alias_func: function
+        Function to generate variable name for pyomo, should take in a 6 inputs and generate a string output.
+        The function will receive following six inputs:
+        - utility: str
+        - charge_type: str
+        - name: str
+        - start_date: str
+        - end_date: str
+        - charge_limit: str
+
+        Examples of functions:
+            f_no_dates=lambda utility, charge_type, name, start_date, end_date, charge_limit: f"{utility}_{charge_type}_{name}_{charge_limit}"
+            f_default=lambda utility, charge_type, name, start_date, end_date, charge_limit: f"{utility}_{charge_type}_{name}_{start_date}_{end_date}_{charge_limit}"
+
     Raises
     ------
     ValueError
@@ -811,9 +826,16 @@ def calculate_cost(
     cost = 0
     n_per_hour = int(60 / ut.get_freq_binsize_minutes(resolution))
     n_per_day = n_per_hour * 24
-
+    if varstr_alias_func is None:
+        varstr_alias_func = lambda utility, charge_type, name, start_date, end_date, charge_limit: f"{utility}_{charge_type}_{name}_{start_date}_{end_date}_{charge_limit}".replace(
+            "-", "_"
+        )
     for key, charge_array in charge_dict.items():
         utility, charge_type, name, eff_start, eff_end, limit_str = key.split("_")
+        var_str = ut.sanitize_varstr(
+            varstr_alias_func(utility, charge_type, name, eff_start, eff_end, limit_str)
+        )
+
         # if we want itemized costs skip irrelvant portions of the bill
         if (desired_utility and utility != desired_utility) or (
             desired_charge_type and charge_type != desired_charge_type
@@ -850,7 +872,7 @@ def calculate_cost(
                 consumption_estimate=consumption_estimate,
                 scale_factor=demand_scale_factor,
                 model=model,
-                varstr=key,
+                varstr=var_str,
             )
             cost += new_cost
         elif charge_type == "energy":
@@ -867,12 +889,12 @@ def calculate_cost(
                 prev_consumption=prev_consumption,
                 consumption_estimate=consumption_estimate,
                 model=model,
-                varstr=key,
+                varstr=var_str,
             )
             cost += new_cost
         elif charge_type == "export":
             new_cost, model = calculate_export_revenues(
-                charge_array, consumption_data, divisor, model=model, varstr=key
+                charge_array, consumption_data, divisor, model=model, varstr=var_str
             )
             cost -= new_cost
         elif charge_type == "customer":

--- a/electric_emission_cost/utils.py
+++ b/electric_emission_cost/utils.py
@@ -502,7 +502,8 @@ def convert_utc_to_timezone(utc_hour, timezone_str):
 
 
 def sanitize_varstr(varstr):
-    """Sanitizes a variable string by removing non-alphanumeric characters and replacing spaces with underscores.
+    """Sanitizes a variable string by removing non-alphanumeric
+    characters and replacing spaces with underscores.
 
     Parameters
     ----------

--- a/electric_emission_cost/utils.py
+++ b/electric_emission_cost/utils.py
@@ -499,3 +499,19 @@ def convert_utc_to_timezone(utc_hour, timezone_str):
     local_time = utc_time.astimezone(target_timezone)
 
     return local_time.hour
+
+
+def sanitize_varstr(varstr):
+    """Sanitizes a variable string by removing non-alphanumeric characters and replacing spaces with underscores.
+
+    Parameters
+    ----------
+    varstr : str
+        The variable string to sanitize.
+
+    Returns
+    -------
+    str
+        The sanitized variable string.
+    """
+    return re.sub(r"[^a-zA-Z0-9_]", "_", varstr).replace(" ", "_")


### PR DESCRIPTION
This add option to pass a function to name pyomo variables (or otherwise) as well as adds a simple utility fun to sanitize name to ensure illigale characters are not passed into name when being created (e.g "-" or ':')
