### PR TITLE
Fixing bug in calculate_demand_cost

### DIFF
--- a/electric_emission_cost/costs.py
+++ b/electric_emission_cost/costs.py
@@ -466,7 +466,7 @@ def calculate_demand_cost(
     scale_factor : float
         Optional factor for scaling demand charges relative to energy charges
         when the optimization/simulation period is not a full billing cycle.
-        Applied to monthly charges where end_date - start_date > 1 day).
+        Applied to monthly charges where end_date - start_date > 1 day.
         Default is 1
 
     model : pyomo.Model
@@ -834,7 +834,7 @@ def calculate_cost(
     demand_scale_factor : float
         Optional factor for scaling demand charges relative to energy charges
         when the optimization/simulation period is not a full billing cycle.
-        Applied to monthly charges where end_date - start_date > 1 day).
+        Applied to monthly charges where end_date - start_date > 1 day.
         Default is 1
 
     model : pyomo.Model

--- a/electric_emission_cost/costs.py
+++ b/electric_emission_cost/costs.py
@@ -466,6 +466,7 @@ def calculate_demand_cost(
     scale_factor : float
         Optional factor for scaling demand charges relative to energy charges
         when the optimization/simulation period is not a full billing cycle.
+        Applied to monthly charges where end_date - start_date > 1 day).
         Default is 1
 
     model : pyomo.Model
@@ -546,17 +547,15 @@ def calculate_demand_cost(
             "consumption_data must be of type numpy.ndarray or cvxpy.Expression"
         )
     if model is None:
-        result, _ = ut.max(demand_charged)
-        max_pos_val, max_pos_model = ut.max_pos(result - prev_demand_cost)
+        max_var, _ = ut.max(demand_charged)
+        max_pos_val, max_pos_model = ut.max_pos(max_var - prev_demand_cost)
         return max_pos_val * scale_factor, max_pos_model
     else:
         max_var, model = ut.max(demand_charged, model=model, varstr=varstr + "_max")
-        return (
-            ut.max_pos(
-                max_var - prev_demand_cost, model=model, varstr=varstr + "_max_pos"
-            )
-            * scale_factor
+        max_pos_val, max_pos_model = ut.max_pos(
+            max_var - prev_demand_cost, model=model, varstr=varstr + "_max_pos"
         )
+        return max_pos_val * scale_factor, max_pos_model
 
 
 def calculate_energy_cost(
@@ -726,6 +725,49 @@ def calculate_export_revenues(
     return revenues / divisor, model
 
 
+def get_charge_array_duration(key):
+    """Parse a charge array key to determine the duration of the charge period.
+
+    Parameters
+    ----------
+    key : str
+        Charge key of form `utility_charge_type_name_start_date_end_date_charge_limit`
+        where start_date and end_date are in YYYYMMDD or YYYY-MM-DD format
+
+    Returns
+    -------
+    int
+        Duration of the charge period in days
+
+    Raises
+    ------
+    ValueError
+        If the key format is invalid or dates cannot be parsed
+    """
+    parts = key.split("_")
+    if len(parts) < 6:
+        raise ValueError(f"Invalid charge key format: {key}")
+
+    start_date_str = parts[-3]
+    end_date_str = parts[-2]
+
+    # Allow 2 date formats
+    date_formats = ["%Y%m%d", "%Y-%m-%d"]
+
+    for date_format in date_formats:
+        try:
+            start_date = dt.datetime.strptime(start_date_str, date_format)
+            end_date = dt.datetime.strptime(end_date_str, date_format)
+            return (end_date - start_date).days
+        except ValueError:
+            continue
+
+    raise ValueError(
+        f"Invalid date format in charge key {key}:"
+        f"cannot parse dates '{start_date_str}' and '{end_date_str}'"
+    )
+
+
 def calculate_cost(
     charge_dict,
     consumption_data_dict,
@@ -792,6 +834,7 @@ def calculate_cost(
     demand_scale_factor : float
         Optional factor for scaling demand charges relative to energy charges
         when the optimization/simulation period is not a full billing cycle.
+        Applied to monthly charges where end_date - start_date > 1 day).
         Default is 1
 
     model : pyomo.Model
@@ -858,6 +901,10 @@ def calculate_cost(
         next_limit = get_next_limit(key_substr, charge_limit, charge_dict.keys())
         consumption_data = consumption_data_dict[utility]
 
+        # Only apply demand_scale_factor if charge spans more than one day
+        charge_duration_days = get_charge_array_duration(key)
+        effective_scale_factor = demand_scale_factor if charge_duration_days > 1 else 1
+
         # TODO: this assumes units of kW for electricity and meters cubed for gas
         if utility == "electric":
             divisor = n_per_hour
@@ -881,7 +928,7 @@ def calculate_cost(
                 prev_demand=prev_demand,
                 prev_demand_cost=prev_demand_cost,
                 consumption_estimate=consumption_estimate,
-                scale_factor=demand_scale_factor,
+                scale_factor=effective_scale_factor,
                 model=model,
                 varstr=var_str,
             )

--- a/electric_emission_cost/costs.py
+++ b/electric_emission_cost/costs.py
@@ -547,7 +547,8 @@ def calculate_demand_cost(
         )
     if model is None:
         result, _ = ut.max(demand_charged)
-        return ut.max_pos(result - prev_demand_cost) * scale_factor
+        max_pos_val, max_pos_model = ut.max_pos(result - prev_demand_cost)
+        return max_pos_val * scale_factor, max_pos_model
     else:
         max_var, model = ut.max(demand_charged, model=model, varstr=varstr + "_max")
         return (

--- a/electric_emission_cost/tests/test_costs.py
+++ b/electric_emission_cost/tests/test_costs.py
@@ -824,7 +824,7 @@ def test_calculate_cost_pyo(
 @pytest.mark.skipif(skip_all_tests, reason="Exclude all tests")
 @pytest.mark.parametrize(
     "start_dt, end_dt, billing_data, utility, consumption_data_dict, "
-    "prev_demand_dict, consumption_estimate, expected",
+    "prev_demand_dict, consumption_estimate, scale_factor, expected",
     [
         (
             np.datetime64("2024-07-10"),  # Summer weekday
@@ -834,7 +834,19 @@ def test_calculate_cost_pyo(
             {"electric": np.arange(96), "gas": np.arange(96)},
             None,
             0,
+            1,  # default scale factor
             np.float64(4027.79),
+        ),
+        (
+            np.datetime64("2024-07-10"),  # Summer weekday
+            np.datetime64("2024-07-11"),  # Summer weekday
+            input_dir + "billing_pge.csv",
+            "electric",
+            {"electric": np.arange(96), "gas": np.arange(96)},
+            None,
+            0,
+            1.1,  # non-default scale factor
+            np.float64(4027.79),  # daily demand charge unscaled
         ),
         (
             np.datetime64("2024-07-13"),  # Summer weekend
@@ -844,6 +856,7 @@ def test_calculate_cost_pyo(
             {"electric": np.arange(96), "gas": np.arange(96)},
             None,
             0,
+            1,  # default scale factor
             np.float64(2023.5),
         ),
         (
@@ -854,6 +867,7 @@ def test_calculate_cost_pyo(
             {"electric": np.arange(96), "gas": np.arange(96)},
             None,
             0,
+            1,  # default scale factor
             np.float64(2028.6),
         ),
         (
@@ -885,6 +899,7 @@ def test_calculate_cost_pyo(
                 },
             },
             0,
+            1,  # default scale factor
             np.float64(2023.5),
         ),
         (
@@ -916,6 +931,7 @@ def test_calculate_cost_pyo(
                 },
             },
             0,
+            1,  # default scale factor
             np.float64(2897.79),
         ),
         (
@@ -926,7 +942,22 @@ def test_calculate_cost_pyo(
             {"electric": np.arange(96), "gas": np.arange(96)},
             None,
             0,
+            1,  # default scale factor
             np.float64(0),
+        ),
+        (
+            np.datetime64("2024-07-10"),  # Summer weekday
+            np.datetime64("2024-07-13"),  # Summer weekday (3 days)
+            input_dir + "billing_pge.csv",
+            "electric",
+            {
+                "electric": np.arange(288),
+                "gas": np.arange(288),
+            },  # 3 days * 96 timesteps
+            None,
+            0,
+            1.1,  # non-default scale factor
+            pytest.approx(14646.313),  # 13314.83 * 1.1
         ),
     ],
 )
@@ -938,6 +969,7 @@ def test_calculate_demand_costs(
     consumption_data_dict,
     prev_demand_dict,
     consumption_estimate,
+    scale_factor,
     expected,
 ):
     billing_data = pd.read_csv(billing_data)
@@ -953,6 +985,7 @@ def test_calculate_demand_costs(
         consumption_estimate=consumption_estimate,
         desired_utility=utility,
         desired_charge_type="demand",
+        demand_scale_factor=scale_factor,
     )
     assert result == expected
     assert model is None
@@ -1092,6 +1125,23 @@ def test_calculate_export_revenues(charge_array, export_data, divisor, expected)
     result, model = costs.calculate_export_revenues(charge_array, export_data, divisor)
     assert result == expected
     assert model is None
+
+
+@pytest.mark.parametrize(
+    "key, expected",
+    [
+        # YYYYMMDD format
+        ("electric_demand_peak_20240710_20240710_100", 0),
+        ("electric_demand_peak_20240710_20240731_100", 21),
+        # YYYY-MM-DD format
+        ("electric_energy_0_2024-07-10_2024-07-10_0", 0),
+        ("electric_energy_0_2024-07-10_2024-07-31_0", 21),
+    ],
+)
+def test_get_charge_array_duration(key, expected):
+    from electric_emission_cost.costs import get_charge_array_duration
+
+    assert get_charge_array_duration(key) == expected
 
 
 # TODO: write test_calculate_itemized_cost


### PR DESCRIPTION
calculate_demand_cost was multiplying the tuple (val, model) returned from ut.max_pos by scale factor, rather than just multiplying the value. This came up when trying to replace the flows-mpc cost module with electric-emission-cost.costs.calculate_costs

Updated to just multiply the value by scale_factor and tests are still passing with the update.